### PR TITLE
fix typo

### DIFF
--- a/README.md
+++ b/README.md
@@ -135,8 +135,8 @@ Structure of config file:
 ```
 {
 "file" : "open-api.json",
-"verbosity" : "normal, 
-"profile" : " "Normal",
+"verbosity" : "Normal", 
+"profile" :   "Normal",
 "passive_include" : ["check1, checks2"],
 "active_include": ["check3, check4"],
 "servers_override" , ["http://server/"],


### PR DESCRIPTION
Fix typo in the example config file